### PR TITLE
Integrated Spotify and Firestore API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   },
   "extends": "eslint:recommended",
   "rules": {
-    "indent": ["error", 2],
+    "indent": ["error", "tab"],
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "single"],
     "semi": ["error", "always"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   },
   "extends": "eslint:recommended",
   "rules": {
-    "indent": ["error", "tab"],
+    "indent": ["error", 1],
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "single"],
     "semi": ["error", "always"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   },
   "extends": "eslint:recommended",
   "rules": {
-    "indent": ["error", "tab"],
+    "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "single"],
     "semi": ["error", "always"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "parser": "babel-eslint",
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "indent": ["error", "tab"],
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "single"],
+    "semi": ["error", "always"]
+  }
+}

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -12,7 +12,8 @@
     "no-underscore-dangle": 0,
     "import/imports-first": ["error", "absolute-first"],
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "react/no-array-index-key": "off"
   },
   "globals": {
     "window": true,

--- a/client/src/api/firebase/firebaseApi.js
+++ b/client/src/api/firebase/firebaseApi.js
@@ -1,22 +1,41 @@
-import { FirebaseAuth, db } from './firebaseConfig';
+import * as firebase from 'firebase';
+import { db } from './firebaseConfig';
 
-/**
- * Creates a new playlist and renders the results
- * @param {String} playlistId ID of the playlist
- * @param {String} ownerId ID of the playlist owner
- * @param {String} playlistName The name of the playlist
- * @return {Object} An object containing playlist data
- */
 function addNewPlaylistToDb(ownerId, playlistId, playlistName) {
-  console.log('adding to firebase.....');
-
   db.doc(`playlists/${playlistId}`).set(
     {
       ownerId,
       playlistName,
+      tracks: [{ trackUri: '', timestamp: null }],
     },
     { merge: true }
   );
 }
 
-export default addNewPlaylistToDb;
+function getPlaylistFromDb(next) {
+  db.collection('playlists')
+    .get()
+    .then(querySnapshot => {
+      querySnapshot.forEach(doc => {
+        // callback function that sends the document data to the next function
+        next(doc);
+      });
+    })
+    .catch(error => {
+      return error;
+    });
+}
+
+function addTrackToDb(trackUri, playlistId) {
+  db.doc(`playlists/${playlistId}`)
+    .update({
+      tracks: firebase.firestore.FieldValue.arrayUnion({
+        trackUri,
+      }),
+    })
+    .catch(error => {
+      return error;
+    });
+}
+
+export { addNewPlaylistToDb, getPlaylistFromDb, addTrackToDb };

--- a/client/src/api/firebase/firebaseConfig.js
+++ b/client/src/api/firebase/firebaseConfig.js
@@ -13,12 +13,15 @@ const config = {
 };
 
 // Initialize Firebase
-firebase.initializeApp(config);
+const FirebaseApp = firebase.initializeApp(config);
+
 // Create an instance of Firebase Auth used to authenticate users
 const FirebaseAuth = firebase.auth();
+
 // Creates an instance of Firestore Database
 const db = firebase.firestore();
+
 // Sets user session in browser
 FirebaseAuth.setPersistence('local');
 
-export { FirebaseAuth, db };
+export { FirebaseAuth, FirebaseApp, db };

--- a/client/src/api/spotify/spotifyApi.js
+++ b/client/src/api/spotify/spotifyApi.js
@@ -1,26 +1,65 @@
 import { SpotifyApi } from './spotifyConfig';
-import { FirebaseAuth } from '../firebase/firebaseConfig';
 
-import addNewPlaylistToDb from '../firebase/firebaseApi';
+import {
+  addNewPlaylistToDb,
+  getPlaylistFromDb,
+  addTrackToDb,
+} from '../firebase/firebaseApi';
 
 function createSpotifyPlaylist(userId, playlistName) {
   SpotifyApi.createPlaylist(userId, playlistName, {
     public: true,
   })
     .then(data => {
-      console.log('new playlist data >>>', data.body);
       const playlistId = data.body.id;
       const ownerId = data.body.owner.id;
-      console.log(ownerId);
+
       return addNewPlaylistToDb(ownerId, playlistId, playlistName);
     })
     .catch(error => {
-      console.log(error);
+      return error;
     });
 }
 
-function getPlaylist() {
-  console.log('getPlaylist');
+function searchTracks(query, setTrackResults) {
+  SpotifyApi.searchTracks(query)
+    .then(data => {
+      setTrackResults(data.body.tracks.items);
+    })
+    .catch(error => {
+      return error;
+    });
 }
 
-export default createSpotifyPlaylist;
+function addTrackToPlaylist(trackUri) {
+  getPlaylistFromDb(doc => {
+    const playlistId = doc.id;
+
+    SpotifyApi.addTracksToPlaylist(playlistId, [trackUri])
+      .then(() => {
+        addTrackToDb(trackUri, playlistId);
+      })
+      .catch(error => {
+        return error;
+      });
+  });
+}
+
+function getPlaylistTracks(next) {
+  getPlaylistFromDb(doc => {
+    const playlistId = doc.id.toString();
+
+    SpotifyApi.getPlaylistTracks(playlistId)
+      .then(data => {
+        next(data.body);
+      })
+      .catch(error => console.log(error));
+  });
+}
+
+export {
+  createSpotifyPlaylist,
+  searchTracks,
+  addTrackToPlaylist,
+  getPlaylistTracks,
+};

--- a/client/src/components/home.js
+++ b/client/src/components/home.js
@@ -1,50 +1,92 @@
 import React, { useState, useContext, useEffect } from 'react';
-import styled from 'styled-components';
-import createPlaylist from '../api/spotify/spotifyApi';
+
+import {
+  createSpotifyPlaylist,
+  searchTracks,
+  addTrackToPlaylist,
+  // getPlaylistTracks,
+} from '../api/spotify/spotifyApi';
+import { SpotifyContext } from '../context/spotifyContext';
+
 import { SpotifyApi } from '../api/spotify/spotifyConfig';
 
-// styled components allow us to grab styles from the themeProvider object globally via props!
-export const Greeting = styled.div`
-  color: ${props => props.theme.colors.fontColor};
-`;
 function Home() {
   const [playlist, setPlaylistName] = useState({
     playlistName: '',
   });
-  // check for user in localStorage:
-  const localUser = JSON.parse(localStorage.getItem('user'));
-  const [user] = useState(() => {
-    if (!localUser) {
-      return 'no user in localStorage';
-    }
-    return localUser;
-  });
 
-  // check for spotifyToken in localStorage (needs to be refactored in more secure way)
-  const spotifyToken = localStorage.getItem('SpotifyAccessToken');
+  const { searchQuery, setSearchQuery } = useContext(SpotifyContext);
+  const { trackResults, setTrackResults } = useContext(SpotifyContext);
 
-  useEffect(() => {
-    return spotifyToken ? SpotifyApi.setAccessToken(spotifyToken) : null;
-  }, [spotifyToken, user]);
+  const user = JSON.parse(localStorage.getItem('user'));
+  SpotifyApi.setAccessToken(user.accessToken);
 
   const handlePlaylistName = e => {
-    console.log(e.target.value);
     setPlaylistName({ playlistName: e.target.value });
+  };
+
+  const search = e => {
+    setSearchQuery({ query: e.target.value });
+  };
+
+  const handleAddTrack = result => {
+    addTrackToPlaylist(result);
   };
 
   return (
     <div>
-      <input
-        type="test"
-        value={playlist.playlistName}
-        onChange={handlePlaylistName}
-      />
-      <button
-        type="submit"
-        onClick={() => createPlaylist(user.uid, playlist.playlistName)}
-      >
-        ADD PLAYLIST
-      </button>
+      <div>
+        {/** ADD PLAYLIST */}
+        <input
+          type="text"
+          value={playlist.playlistName}
+          onChange={handlePlaylistName}
+          placeholder="Create A Playlist"
+        />
+        <button
+          type="submit"
+          onClick={() => createSpotifyPlaylist(user.uid, playlist.playlistName)}
+        >
+          CREATE PLAYLIST
+        </button>
+        <br />
+        <br />
+
+        {/** SEARCH FOR A SONG */}
+        <input
+          type="text"
+          value={searchQuery.query}
+          onChange={search}
+          placeholder="Search Tracks"
+        />
+        <button
+          type="submit"
+          onClick={() => searchTracks(searchQuery.query, setTrackResults)}
+        >
+          SEARCH
+        </button>
+      </div>
+
+      {/** SEARCH RESULTS */}
+      {trackResults.data !== '' ? (
+        trackResults.map((result, i) => (
+          <ul key={i}>
+            <li>
+              <img src={result.album.images[2].url} alt="album-cover" />
+              {result.artists[0].name} - {result.name}
+              {/* {console.log(result)} */}
+              <button
+                type="submit"
+                onClick={() => handleAddTrack(result.uri.toString())}
+              >
+                add
+              </button>
+            </li>
+          </ul>
+        ))
+      ) : (
+        <h2>Start adding some tunes!</h2>
+      )}
     </div>
   );
 }

--- a/client/src/components/login.js
+++ b/client/src/components/login.js
@@ -2,58 +2,47 @@ import React, { useState, useEffect, useContext } from 'react';
 import axios from 'axios';
 import { FirebaseAuth, db } from '../api/firebase/firebaseConfig';
 import { spotifyAuthEndpoint, SpotifyApi } from '../api/spotify/spotifyConfig';
-import { getCookie, getUrlParameter } from '../utils/helpers';
+import { getUrlParameter } from '../utils/helpers';
 
 // TODO:
 // After login, figure out a way to pass the SpotifyAccessToken without putting it in localStorage. handle in userContext?
-
-// import contexts
-import { FirebaseContext } from '../context/firebaseContext';
-import { SpotifyContext } from '../context/spotifyContext';
 
 function Login() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const spotifyAuthCode = getUrlParameter('code');
 
   useEffect(() => {
-    // Check Firebase if user is logged in and session is still valid.
-    // If session is not valid, user will need to login again.
-    FirebaseAuth.onAuthStateChanged(authUser => {
-      if (authUser) {
-        // get user data from firestore db
-        authUser.getIdToken().then(idToken => {
-          const { uid, email, metadata } = authUser;
-          // create an object to merge authUser data (email, uid) with data from db
-          const userData = {
-            uid,
-            email,
-            idToken,
-            lastSignInTime: metadata.lastSignInTime,
-            creationTime: metadata.creationTime,
-          };
-          // I think setting user to localStorage would work best here:
-          localStorage.setItem('user', JSON.stringify(userData));
-          localStorage.setItem('idToken', idToken);
-        });
-      }
-    });
-    // If a user logs in and generates a new Spotify access code, send the code to the server to save to db and reauthenticate.
-    if (spotifyAuthCode && !isAuthenticated) {
-      // removed csrfToken parameter, see line 15
-      axios.post('/auth/token', { spotifyAuthCode }).then(async response => {
-        // adding this to localStorage for now, but should probably think of a more secure solution before deployment
-        localStorage.setItem(
-          'SpotifyAccessToken',
-          response.data.spotifyAccessToken
-        );
-        FirebaseAuth.setPersistence('local').then(async () => {
-          await FirebaseAuth.signInWithCustomToken(response.data.firebaseToken)
-            .then(() => setIsAuthenticated(true))
-            .catch(error => error);
-        });
+    const authListener = () => {
+      FirebaseAuth.onAuthStateChanged(authUser => {
+        if (authUser) {
+          db.doc(`users/${authUser.uid}`)
+            .get()
+            .then(snapshot => {
+              const dbUser = snapshot.data();
+              console.log(dbUser);
+
+              // merge auth and db user
+              const userData = {
+                uid: authUser.uid,
+                email: authUser.email,
+                ...dbUser,
+              };
+              // I think setting user to localStorage would work best here:
+              localStorage.setItem('user', JSON.stringify(userData));
+            });
+        }
       });
-    }
-  });
+    };
+
+    axios.post('/auth/token', { spotifyAuthCode }).then(async response => {
+      FirebaseAuth.setPersistence('local').then(async () => {
+        await FirebaseAuth.signInWithCustomToken(response.data.firebaseToken)
+          .then(() => setIsAuthenticated(true))
+          .catch(error => error);
+      });
+    });
+    authListener();
+  }, [spotifyAuthCode]);
 
   return (
     <div id="login">

--- a/client/src/context/spotifyContext.js
+++ b/client/src/context/spotifyContext.js
@@ -6,12 +6,20 @@ export const SpotifyContext = React.createContext();
 // create context provider
 export const SpotifyProvider = ({ children }) => {
   const [spotifyToken, setSpotifyToken] = useState();
+  const [searchQuery, setSearchQuery] = useState({ query: '' });
+  const [trackResults, setTrackResults] = useState({
+    data: '',
+  });
   return (
     // inject state into the provider, and pass along to children components
     <SpotifyContext.Provider
       value={{
         spotifyToken,
         setSpotifyToken,
+        searchQuery,
+        setSearchQuery,
+        trackResults,
+        setTrackResults,
       }}
     >
       {children}

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "airbnb-base"
-}

--- a/server/firebase/firebaseApi.js
+++ b/server/firebase/firebaseApi.js
@@ -2,99 +2,99 @@ const { FirebaseAdmin, FirebaseApp } = require('../config');
 
 // Stores the Spotify access token each time a new one is created
 function databaseCreation(uid, email, accessToken, refreshToken) {
-	return FirebaseAdmin.firestore()
-		.doc(`users/${uid}`)
-		.set({
-			email,
-			accessToken,
-			refreshToken,
-		});
+ return FirebaseAdmin.firestore()
+  .doc(`users/${uid}`)
+  .set({
+   email,
+   accessToken,
+   refreshToken,
+  });
 }
 
 // Updates or create Firebase user information
 async function userUpdateOrCreateUser(uid, email) {
-	return FirebaseAdmin.auth()
-		.updateUser(uid, {
-			email,
+ return FirebaseAdmin.auth()
+  .updateUser(uid, {
+   email,
 
-			emailVerified: true,
-		})
-		.catch(error => {
-			// If user does not exists we create it.
-			if (error.code === 'auth/user-not-found') {
-				return FirebaseAdmin.auth().createUser({
-					uid,
-					email,
+   emailVerified: true,
+  })
+  .catch(error => {
+   // If user does not exists we create it.
+   if (error.code === 'auth/user-not-found') {
+    return FirebaseAdmin.auth().createUser({
+     uid,
+     email,
 
-					emailVerified: true,
-				});
-			}
-			return error;
-		});
+     emailVerified: true,
+    });
+   }
+   return error;
+  });
 }
 
 // Creates custom Firebase authentication tokens
 function createFirebaseToken(uid, providerData) {
-	const token = FirebaseAdmin.auth().createCustomToken(uid, {
-		providerData: [{ spotify: providerData }],
-		admin: true,
-	});
-	return token;
+ const token = FirebaseAdmin.auth().createCustomToken(uid, {
+  providerData: [{ spotify: providerData }],
+  admin: true,
+ });
+ return token;
 }
 
 // Creates a user and database entry in the `users` collection
 async function createOrUpdateFirebaseAccount(
-	spotifyID,
-	email,
-	accessToken,
-	refreshToken,
-	providerData
+ spotifyID,
+ email,
+ accessToken,
+ refreshToken,
+ providerData
 ) {
-	const uid = spotifyID;
-	const databaseCreationTask = databaseCreation(
-		uid,
-		email,
-		accessToken,
-		refreshToken
-	);
-	const userCreationTask = userUpdateOrCreateUser(uid, email);
+ const uid = spotifyID;
+ const databaseCreationTask = databaseCreation(
+  uid,
+  email,
+  accessToken,
+  refreshToken
+ );
+ const userCreationTask = userUpdateOrCreateUser(uid, email);
 
-	// Wait til the database entry and user is made, create a custom token and send to the client.
-	return Promise.all([databaseCreationTask, userCreationTask])
-		.then(() => {
-			return createFirebaseToken(uid, providerData);
-		})
-		.catch(err => {
-			return err;
-		});
+ // Wait til the database entry and user is made, create a custom token and send to the client.
+ return Promise.all([databaseCreationTask, userCreationTask])
+  .then(() => {
+   return createFirebaseToken(uid, providerData);
+  })
+  .catch(err => {
+   return err;
+  });
 }
 
 // Verify identity of the user
 function verifyUserIdToken(idToken) {
-	return FirebaseAdmin.auth().verifyIdToken(idToken);
+ return FirebaseAdmin.auth().verifyIdToken(idToken);
 }
 
 // Creates a user session to stay logged into the Firebase server
 function createUserSession(idToken, expiresIn) {
-	return FirebaseAdmin.auth().createSessionCookie(idToken, { expiresIn });
+ return FirebaseAdmin.auth().createSessionCookie(idToken, { expiresIn });
 }
 
 // Verify the user session
 function verifySession(sessionCookie) {
-	return FirebaseAdmin.auth().verifySessionCookie(sessionCookie, true);
+ return FirebaseAdmin.auth().verifySessionCookie(sessionCookie, true);
 }
 
 // Revoke
 function revokeToken(claims) {
-	return FirebaseAdmin.revokeRefreshTokens(decodedClaims.sub);
+ return FirebaseAdmin.revokeRefreshTokens(decodedClaims.sub);
 }
 
 module.exports = {
-	FirebaseAdmin,
-	FirebaseApp,
-	createOrUpdateFirebaseAccount,
-	verifyUserIdToken,
-	createUserSession,
-	verifySession,
-	revokeToken,
+ FirebaseAdmin,
+ FirebaseApp,
+ createOrUpdateFirebaseAccount,
+ verifyUserIdToken,
+ createUserSession,
+ verifySession,
+ revokeToken,
 };

--- a/server/firebase/firebaseApi.js
+++ b/server/firebase/firebaseApi.js
@@ -2,7 +2,6 @@ const { FirebaseAdmin, FirebaseApp } = require('../config');
 
 // Stores the Spotify access token each time a new one is created
 function databaseCreation(uid, email, accessToken, refreshToken) {
-  console.log('FirebaseAdmin: ', FirebaseAdmin);
   return FirebaseAdmin.firestore()
     .doc(`users/${uid}`)
     .set({

--- a/server/firebase/firebaseApi.js
+++ b/server/firebase/firebaseApi.js
@@ -2,99 +2,99 @@ const { FirebaseAdmin, FirebaseApp } = require('../config');
 
 // Stores the Spotify access token each time a new one is created
 function databaseCreation(uid, email, accessToken, refreshToken) {
-  return FirebaseAdmin.firestore()
-    .doc(`users/${uid}`)
-    .set({
-      email,
-      accessToken,
-      refreshToken,
-    });
+	return FirebaseAdmin.firestore()
+		.doc(`users/${uid}`)
+		.set({
+			email,
+			accessToken,
+			refreshToken,
+		});
 }
 
 // Updates or create Firebase user information
 async function userUpdateOrCreateUser(uid, email) {
-  return FirebaseAdmin.auth()
-    .updateUser(uid, {
-      email,
+	return FirebaseAdmin.auth()
+		.updateUser(uid, {
+			email,
 
-      emailVerified: true,
-    })
-    .catch(error => {
-      // If user does not exists we create it.
-      if (error.code === 'auth/user-not-found') {
-        return FirebaseAdmin.auth().createUser({
-          uid,
-          email,
+			emailVerified: true,
+		})
+		.catch(error => {
+			// If user does not exists we create it.
+			if (error.code === 'auth/user-not-found') {
+				return FirebaseAdmin.auth().createUser({
+					uid,
+					email,
 
-          emailVerified: true,
-        });
-      }
-      return error;
-    });
+					emailVerified: true,
+				});
+			}
+			return error;
+		});
 }
 
 // Creates custom Firebase authentication tokens
 function createFirebaseToken(uid, providerData) {
-  const token = FirebaseAdmin.auth().createCustomToken(uid, {
-    providerData: [{ spotify: providerData }],
-    admin: true,
-  });
-  return token;
+	const token = FirebaseAdmin.auth().createCustomToken(uid, {
+		providerData: [{ spotify: providerData }],
+		admin: true,
+	});
+	return token;
 }
 
 // Creates a user and database entry in the `users` collection
 async function createOrUpdateFirebaseAccount(
-  spotifyID,
-  email,
-  accessToken,
-  refreshToken,
-  providerData
+	spotifyID,
+	email,
+	accessToken,
+	refreshToken,
+	providerData
 ) {
-  const uid = spotifyID;
-  const databaseCreationTask = databaseCreation(
-    uid,
-    email,
-    accessToken,
-    refreshToken
-  );
-  const userCreationTask = userUpdateOrCreateUser(uid, email);
+	const uid = spotifyID;
+	const databaseCreationTask = databaseCreation(
+		uid,
+		email,
+		accessToken,
+		refreshToken
+	);
+	const userCreationTask = userUpdateOrCreateUser(uid, email);
 
-  // Wait til the database entry and user is made, create a custom token and send to the client.
-  return Promise.all([databaseCreationTask, userCreationTask])
-    .then(() => {
-      return createFirebaseToken(uid, providerData);
-    })
-    .catch(err => {
-      return err;
-    });
+	// Wait til the database entry and user is made, create a custom token and send to the client.
+	return Promise.all([databaseCreationTask, userCreationTask])
+		.then(() => {
+			return createFirebaseToken(uid, providerData);
+		})
+		.catch(err => {
+			return err;
+		});
 }
 
 // Verify identity of the user
 function verifyUserIdToken(idToken) {
-  return FirebaseAdmin.auth().verifyIdToken(idToken);
+	return FirebaseAdmin.auth().verifyIdToken(idToken);
 }
 
 // Creates a user session to stay logged into the Firebase server
 function createUserSession(idToken, expiresIn) {
-  return FirebaseAdmin.auth().createSessionCookie(idToken, { expiresIn });
+	return FirebaseAdmin.auth().createSessionCookie(idToken, { expiresIn });
 }
 
 // Verify the user session
 function verifySession(sessionCookie) {
-  return FirebaseAdmin.auth().verifySessionCookie(sessionCookie, true);
+	return FirebaseAdmin.auth().verifySessionCookie(sessionCookie, true);
 }
 
 // Revoke
 function revokeToken(claims) {
-  return FirebaseAdmin.revokeRefreshTokens(decodedClaims.sub);
+	return FirebaseAdmin.revokeRefreshTokens(decodedClaims.sub);
 }
 
 module.exports = {
-  FirebaseAdmin,
-  FirebaseApp,
-  createOrUpdateFirebaseAccount,
-  verifyUserIdToken,
-  createUserSession,
-  verifySession,
-  revokeToken,
+	FirebaseAdmin,
+	FirebaseApp,
+	createOrUpdateFirebaseAccount,
+	verifyUserIdToken,
+	createUserSession,
+	verifySession,
+	revokeToken,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,50 +1,17 @@
 require('dotenv').config();
 const express = require('express');
 const bp = require('body-parser');
-const crypto = require('crypto');
-const cookieParser = require('cookie-parser');
 const authRoutes = require('./routes/auth');
-const {
-  checkIfSignedIn,
-  attachCsrfToken,
-} = require('./utils/customMiddleware');
 
 const PORT = process.env.PORT || 8080;
 const app = express();
 
-<<<<<<< HEAD
-=======
-console.log('hello from mars');
-
-const corsOptions = {
-  origin: function(origin, callback) {
-    if (CORS_WHITELIST.indexOf(origin) !== -1 || !origin) {
-      return callback(null, true);
-    } else {
-      return callback(new Error('Not allowed by CORS'));
-    }
-  },
-  credentials: true,
-  exposedHeaders: ['Authorization'],
-};
-
-app.use(cors(corsOptions));
-
->>>>>>> dev
 app.use(bp.json());
 app.use(
   bp.urlencoded({
     extended: true,
   })
 );
-// Support cookie manipulation.
-app.use(cookieParser());
-// Set csrf token on every request
-app.use(
-  attachCsrfToken('/', 'csrfToken', crypto.randomBytes(20).toString('hex'))
-);
-// If a user is signed in, redirect to home page
-app.use(checkIfSignedIn('/'));
 
 app.use('/auth', authRoutes);
 

--- a/server/index.js
+++ b/server/index.js
@@ -8,13 +8,13 @@ const app = express();
 
 app.use(bp.json());
 app.use(
-  bp.urlencoded({
-    extended: true,
-  })
+	bp.urlencoded({
+		extended: true,
+	})
 );
 
 app.use('/auth', authRoutes);
 
 app.listen(PORT, () => {
-  console.log(`Magic happening on ${PORT}`);
+	console.log(`Magic happening on ${PORT}`);
 });

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,68 +3,68 @@ const router = express.Router();
 const { SpotifyApi } = require('../config/index');
 
 const {
-	createOrUpdateFirebaseAccount,
-	verifySession,
-	revokeToken,
+ createOrUpdateFirebaseAccount,
+ verifySession,
+ revokeToken,
 } = require('../firebase/firebaseApi');
 
 router.post('/token', (req, res) => {
-	const authCode = req.body.spotifyAuthCode;
+ const authCode = req.body.spotifyAuthCode;
 
-	// Start the Spotify auth flow
-	SpotifyApi.authorizationCodeGrant(authCode)
-		.then(data => {
-			const { access_token, refresh_token } = data.body;
-			// Set the access token to send on each server request
-			SpotifyApi.setAccessToken(access_token);
-			// Get Spotify user information
-			SpotifyApi.getMe().then(async userResults => {
-				const { email, id } = userResults.body;
-				const uid = id;
+ // Start the Spotify auth flow
+ SpotifyApi.authorizationCodeGrant(authCode)
+  .then(data => {
+   const { access_token, refresh_token } = data.body;
+   // Set the access token to send on each server request
+   SpotifyApi.setAccessToken(access_token);
+   // Get Spotify user information
+   SpotifyApi.getMe().then(async userResults => {
+    const { email, id } = userResults.body;
+    const uid = id;
 
-				// Custom token created after receiving Spotify user information
-				const firebaseToken = await createOrUpdateFirebaseAccount(
-					uid,
-					email,
-					access_token,
-					refresh_token
-				);
+    // Custom token created after receiving Spotify user information
+    const firebaseToken = await createOrUpdateFirebaseAccount(
+     uid,
+     email,
+     access_token,
+     refresh_token
+    );
 
-				// Send user information and tokens to client
-				res.status(201).send({
-					uid,
-					email,
-					firebaseToken,
-				});
-			});
-		})
-		.catch(error => {
-			return error;
-		});
+    // Send user information and tokens to client
+    res.status(201).send({
+     uid,
+     email,
+     firebaseToken,
+    });
+   });
+  })
+  .catch(error => {
+   return error;
+  });
 });
 
 router.get('/logout', (req, res) => {
-	// Clear cookie.
-	let sessionCookie = req.cookies.session || '';
-	res.clearCookie('session');
-	// Revoke session
-	if (sessionCookie) {
-		verifySession(sessionCookie, true)
-			.then(decodedClaims => {
-				return revokeToken(decodedClaims.sub);
-			})
-			.then(() => {
-				// Redirect to login page on success.
-				res.redirect(process.env.CLIENT_URL);
-			})
-			.catch(() => {
-				// Redirect to login page on error.
-				res.redirect(process.env.CLIENT_URL);
-			});
-	} else {
-		// Redirect to login page when no session cookie available.
-		res.redirect(process.env.CLIENT_URL);
-	}
+ // Clear cookie.
+ let sessionCookie = req.cookies.session || '';
+ res.clearCookie('session');
+ // Revoke session
+ if (sessionCookie) {
+  verifySession(sessionCookie, true)
+   .then(decodedClaims => {
+    return revokeToken(decodedClaims.sub);
+   })
+   .then(() => {
+    // Redirect to login page on success.
+    res.redirect(process.env.CLIENT_URL);
+   })
+   .catch(() => {
+    // Redirect to login page on error.
+    res.redirect(process.env.CLIENT_URL);
+   });
+ } else {
+  // Redirect to login page when no session cookie available.
+  res.redirect(process.env.CLIENT_URL);
+ }
 });
 
 module.exports = router;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,70 +3,70 @@ const router = express.Router();
 const { SpotifyApi } = require('../config/index');
 
 const {
-	createOrUpdateFirebaseAccount,
-	verifyUserIdToken,
-	createUserSession,
-	verifySession,
-	revokeToken,
+  createOrUpdateFirebaseAccount,
+  verifyUserIdToken,
+  createUserSession,
+  verifySession,
+  revokeToken,
 } = require('../firebase/firebaseApi');
 
 router.post('/token', (req, res) => {
-	const authCode = req.body.spotifyAuthCode;
+  const authCode = req.body.spotifyAuthCode;
 
-	// Start the Spotify auth flow
-	SpotifyApi.authorizationCodeGrant(authCode)
-		.then(data => {
-			const { access_token, refresh_token } = data.body;
-			// Set the access token to send on each server request
-			SpotifyApi.setAccessToken(access_token);
-			// Get Spotify user information
-			SpotifyApi.getMe().then(async userResults => {
-				const { email, id } = userResults.body;
-				const uid = id;
+  // Start the Spotify auth flow
+  SpotifyApi.authorizationCodeGrant(authCode)
+    .then(data => {
+      const { access_token, refresh_token } = data.body;
+      // Set the access token to send on each server request
+      SpotifyApi.setAccessToken(access_token);
+      // Get Spotify user information
+      SpotifyApi.getMe().then(async userResults => {
+        const { email, id } = userResults.body;
+        const uid = id;
 
-				// Custom token created after receiving Spotify user information
-				const firebaseToken = await createOrUpdateFirebaseAccount(
-					uid,
-					email,
-					access_token,
-					refresh_token
-				);
+        // Custom token created after receiving Spotify user information
+        const firebaseToken = await createOrUpdateFirebaseAccount(
+          uid,
+          email,
+          access_token,
+          refresh_token
+        );
 
-				// Send user information and tokens to client
-				res.status(201).send({
-					uid,
-					email,
-					firebaseToken,
-				});
-			});
-		})
-		.catch(error => {
-			return error;
-		});
+        // Send user information and tokens to client
+        res.status(201).send({
+          uid,
+          email,
+          firebaseToken,
+        });
+      });
+    })
+    .catch(error => {
+      return error;
+    });
 });
 
 router.get('/logout', (req, res) => {
-	// Clear cookie.
-	let sessionCookie = req.cookies.session || '';
-	res.clearCookie('session');
-	// Revoke session
-	if (sessionCookie) {
-		verifySession(sessionCookie, true)
-			.then(decodedClaims => {
-				return revokeToken(decodedClaims.sub);
-			})
-			.then(() => {
-				// Redirect to login page on success.
-				res.redirect(process.env.CLIENT_URL);
-			})
-			.catch(() => {
-				// Redirect to login page on error.
-				res.redirect(process.env.CLIENT_URL);
-			});
-	} else {
-		// Redirect to login page when no session cookie available.
-		res.redirect(process.env.CLIENT_URL);
-	}
+  // Clear cookie.
+  let sessionCookie = req.cookies.session || '';
+  res.clearCookie('session');
+  // Revoke session
+  if (sessionCookie) {
+    verifySession(sessionCookie, true)
+      .then(decodedClaims => {
+        return revokeToken(decodedClaims.sub);
+      })
+      .then(() => {
+        // Redirect to login page on success.
+        res.redirect(process.env.CLIENT_URL);
+      })
+      .catch(() => {
+        // Redirect to login page on error.
+        res.redirect(process.env.CLIENT_URL);
+      });
+  } else {
+    // Redirect to login page when no session cookie available.
+    res.redirect(process.env.CLIENT_URL);
+  }
 });
 
 module.exports = router;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,109 +3,70 @@ const router = express.Router();
 const { SpotifyApi } = require('../config/index');
 
 const {
-  createOrUpdateFirebaseAccount,
-  verifyUserIdToken,
-  createUserSession,
-  verifySession,
-  revokeToken,
+	createOrUpdateFirebaseAccount,
+	verifyUserIdToken,
+	createUserSession,
+	verifySession,
+	revokeToken,
 } = require('../firebase/firebaseApi');
 
 router.post('/token', (req, res) => {
-  const authCode = req.body.spotifyAuthCode;
+	const authCode = req.body.spotifyAuthCode;
 
-  // Start the Spotify auth flow
-  SpotifyApi.authorizationCodeGrant(authCode)
-    .then(data => {
-      const { access_token, refresh_token } = data.body;
-      // Set the access token to send on each server request
-      SpotifyApi.setAccessToken(access_token);
-      // Get Spotify user information
-      SpotifyApi.getMe().then(async userResults => {
-        const { email, id, href } = userResults.body;
-        const uid = id;
+	// Start the Spotify auth flow
+	SpotifyApi.authorizationCodeGrant(authCode)
+		.then(data => {
+			const { access_token, refresh_token } = data.body;
+			// Set the access token to send on each server request
+			SpotifyApi.setAccessToken(access_token);
+			// Get Spotify user information
+			SpotifyApi.getMe().then(async userResults => {
+				const { email, id } = userResults.body;
+				const uid = id;
 
-        // Custom token created after receiving Spotify user information
-        const firebaseToken = await createOrUpdateFirebaseAccount(
-          uid,
-          email,
-          access_token,
-          refresh_token,
-          { access_token, refresh_token, href }
-        );
+				// Custom token created after receiving Spotify user information
+				const firebaseToken = await createOrUpdateFirebaseAccount(
+					uid,
+					email,
+					access_token,
+					refresh_token
+				);
 
-        // Send user information and tokens to client
-        res.status(201).send({
-          uid: id,
-          email,
-          firebaseToken,
-          spotifyAccessToken: access_token,
-          spotifyRefreshToken: refresh_token,
-          spotifyApiHref: href,
-        });
-      });
-    })
-    .catch(error => {
-      return error;
-    });
-});
-
-router.post('/session', (req, res) => {
-  console.log('hitting session route....');
-  const idToken = req.body.idToken;
-  // Get ID token and CSRF token.
-  const csrfToken = req.body.csrfToken;
-
-  // Guard against CSRF attacks.
-  // TODO:
-  // *** Figure out why Spotify isn't sending csrf token on request
-  // if (!req.cookies || csrfToken !== req.cookies.csrfToken) {
-  //   res.status(401).send('UNAUTHORIZED REQUEST!');
-  //   return;
-  // }
-
-  // Set session expiration to 5 days.
-  const expiresIn = 60 * 60 * 24 * 10 * 1000;
-  // Create the session cookie and verify the ID token.
-  verifyUserIdToken(idToken)
-    .then(user => {
-      createUserSession(idToken, expiresIn).then(sessionCookie => {
-        const options = {
-          maxAge: expiresIn,
-          httpOnly: true,
-          secure: false, // Must be set to true in production!!
-        };
-        // Set a server-side user session
-        res.cookie('session', sessionCookie, options);
-        res.status(201).send({ user, isAuthenticated: true });
-      });
-    })
-    .catch(error => {
-      res.status(401).send({ errorMessage: 'UNAUTHORIZED REQUEST!' });
-    });
+				// Send user information and tokens to client
+				res.status(201).send({
+					uid,
+					email,
+					firebaseToken,
+				});
+			});
+		})
+		.catch(error => {
+			return error;
+		});
 });
 
 router.get('/logout', (req, res) => {
-  // Clear cookie.
-  let sessionCookie = req.cookies.session || '';
-  res.clearCookie('session');
-  // Revoke session
-  if (sessionCookie) {
-    verifySession(sessionCookie, true)
-      .then(decodedClaims => {
-        return revokeToken(decodedClaims.sub);
-      })
-      .then(() => {
-        // Redirect to login page on success.
-        res.redirect(process.env.CLIENT_URL);
-      })
-      .catch(() => {
-        // Redirect to login page on error.
-        res.redirect(process.env.CLIENT_URL);
-      });
-  } else {
-    // Redirect to login page when no session cookie available.
-    res.redirect(process.env.CLIENT_URL);
-  }
+	// Clear cookie.
+	let sessionCookie = req.cookies.session || '';
+	res.clearCookie('session');
+	// Revoke session
+	if (sessionCookie) {
+		verifySession(sessionCookie, true)
+			.then(decodedClaims => {
+				return revokeToken(decodedClaims.sub);
+			})
+			.then(() => {
+				// Redirect to login page on success.
+				res.redirect(process.env.CLIENT_URL);
+			})
+			.catch(() => {
+				// Redirect to login page on error.
+				res.redirect(process.env.CLIENT_URL);
+			});
+	} else {
+		// Redirect to login page when no session cookie available.
+		res.redirect(process.env.CLIENT_URL);
+	}
 });
 
 module.exports = router;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,70 +3,68 @@ const router = express.Router();
 const { SpotifyApi } = require('../config/index');
 
 const {
-  createOrUpdateFirebaseAccount,
-  verifyUserIdToken,
-  createUserSession,
-  verifySession,
-  revokeToken,
+	createOrUpdateFirebaseAccount,
+	verifySession,
+	revokeToken,
 } = require('../firebase/firebaseApi');
 
 router.post('/token', (req, res) => {
-  const authCode = req.body.spotifyAuthCode;
+	const authCode = req.body.spotifyAuthCode;
 
-  // Start the Spotify auth flow
-  SpotifyApi.authorizationCodeGrant(authCode)
-    .then(data => {
-      const { access_token, refresh_token } = data.body;
-      // Set the access token to send on each server request
-      SpotifyApi.setAccessToken(access_token);
-      // Get Spotify user information
-      SpotifyApi.getMe().then(async userResults => {
-        const { email, id } = userResults.body;
-        const uid = id;
+	// Start the Spotify auth flow
+	SpotifyApi.authorizationCodeGrant(authCode)
+		.then(data => {
+			const { access_token, refresh_token } = data.body;
+			// Set the access token to send on each server request
+			SpotifyApi.setAccessToken(access_token);
+			// Get Spotify user information
+			SpotifyApi.getMe().then(async userResults => {
+				const { email, id } = userResults.body;
+				const uid = id;
 
-        // Custom token created after receiving Spotify user information
-        const firebaseToken = await createOrUpdateFirebaseAccount(
-          uid,
-          email,
-          access_token,
-          refresh_token
-        );
+				// Custom token created after receiving Spotify user information
+				const firebaseToken = await createOrUpdateFirebaseAccount(
+					uid,
+					email,
+					access_token,
+					refresh_token
+				);
 
-        // Send user information and tokens to client
-        res.status(201).send({
-          uid,
-          email,
-          firebaseToken,
-        });
-      });
-    })
-    .catch(error => {
-      return error;
-    });
+				// Send user information and tokens to client
+				res.status(201).send({
+					uid,
+					email,
+					firebaseToken,
+				});
+			});
+		})
+		.catch(error => {
+			return error;
+		});
 });
 
 router.get('/logout', (req, res) => {
-  // Clear cookie.
-  let sessionCookie = req.cookies.session || '';
-  res.clearCookie('session');
-  // Revoke session
-  if (sessionCookie) {
-    verifySession(sessionCookie, true)
-      .then(decodedClaims => {
-        return revokeToken(decodedClaims.sub);
-      })
-      .then(() => {
-        // Redirect to login page on success.
-        res.redirect(process.env.CLIENT_URL);
-      })
-      .catch(() => {
-        // Redirect to login page on error.
-        res.redirect(process.env.CLIENT_URL);
-      });
-  } else {
-    // Redirect to login page when no session cookie available.
-    res.redirect(process.env.CLIENT_URL);
-  }
+	// Clear cookie.
+	let sessionCookie = req.cookies.session || '';
+	res.clearCookie('session');
+	// Revoke session
+	if (sessionCookie) {
+		verifySession(sessionCookie, true)
+			.then(decodedClaims => {
+				return revokeToken(decodedClaims.sub);
+			})
+			.then(() => {
+				// Redirect to login page on success.
+				res.redirect(process.env.CLIENT_URL);
+			})
+			.catch(() => {
+				// Redirect to login page on error.
+				res.redirect(process.env.CLIENT_URL);
+			});
+	} else {
+		// Redirect to login page when no session cookie available.
+		res.redirect(process.env.CLIENT_URL);
+	}
 });
 
 module.exports = router;


### PR DESCRIPTION
Added the following features:

Firestore API:
* `getPlaylistFromDb` - Retrieves a playlist by id from the database
* `addTrackToDb` - Adds a track to a user's playlist and stores that information on the playlist collection in Firestore

Spotify:
* `searchTracks` - Searches for a track by name, album, or artist on Spotify then sets the search queries in  `SpotifyContext`
* `addTrackToPlaylist` - Adds a track to the shared playlist on Spotify
* `getPlaylistTracks` - Retrieves a Spotify playlist and returns tracks and metadata.

Spotify Context:
* Added context to store search queries and results

Server & Client Login:
* Removed unused code