### PR TITLE
Add realtime updates to tuneroom component

### DIFF
--- a/client/src/api/firebase/firebaseApi.js
+++ b/client/src/api/firebase/firebaseApi.js
@@ -41,6 +41,7 @@ function addTrackToDb(track, accessCodeId) {
     .doc(track.uri)
     .set({
       ...track,
+      votes: 0,
     });
 }
 

--- a/client/src/components/tuneroom.js
+++ b/client/src/components/tuneroom.js
@@ -65,9 +65,11 @@ function TuneRoom() {
   } = useContext(SpotifyContext);
 
   const [localDocumentUri, setLocalDocumentUri] = useState(documentUri);
+  // const [localDocumentState, setLocalDocumentState] = useState(documentState);
 
   useEffect(() => {
     setDocumentState(documentState);
+    // setLocalDocumentState(documentState);
     setLocalDocumentUri(documentUri.uri);
   }, [documentState, documentUri.uri, setDocumentState]);
 

--- a/client/src/context/spotifyContext.js
+++ b/client/src/context/spotifyContext.js
@@ -5,14 +5,7 @@ export const SpotifyContext = React.createContext();
 
 export const SpotifyProvider = ({ children }) => {
   // ACCESS TOKEN -> set when user joins with an accessCode, or creates a new playlsit, generating an accessCode
-  // const [contextAccessCode, setContextAccessCode] = useState()
-  // const myAccessCode = localStorage.getItem('accessCode') || 'default';
   const [myAccessCode, setMyAccessCode] = useState('default');
-
-  // useEffect(() => {
-  //   console.log('THIS IS CONTEXT MOUNTING');
-  //   // setMyAccessCode(localStorage.getItem('accessCode'));
-  // }, [myAccessCode]);
 
   // FIRESTORE DATABASE CONTEXT -> needed to render and play songs
   const [documentOwnerId, setDocumentOwnerId] = useState({ data: '' });
@@ -29,13 +22,10 @@ export const SpotifyProvider = ({ children }) => {
     expiresIn: '',
   });
 
-  // create a useEffect to fetch playlist from firestore, and set to context, depends on localStorage value, which is set in /join
-  // see cleanup, should run this effect whenever the accessCode gets changed in localStorage
   useEffect(() => {
     setMyAccessCode(localStorage.getItem('accessCode'));
     async function fetchData() {
-      // placeholder array to push tracks into, see below
-      const playlistArr = [];
+      // let playlistArr = [];
       const playlistRef = db.doc(`playlists/${myAccessCode}`);
       playlistRef
         .get()
@@ -47,16 +37,19 @@ export const SpotifyProvider = ({ children }) => {
           await setDocumentPlaylistId({ data: doc.data().playlistId });
           await setDocumentUri({ uri: doc.data().uri });
           await setDocumentPlaylistName({ data: doc.data().playlistName });
-
-          await playlistRef
-            .collection('tracks')
-            .get()
-            .then(item => {
-              item.docs.map(track => {
-                playlistArr.push(track.data());
+          await playlistRef.collection('tracks').onSnapshot(
+            {
+              // Listen for document metadata changes
+              includeMetadataChanges: true,
+            },
+            async snapDoc => {
+              let playlistArr = [];
+              snapDoc.docs.forEach(item => {
+                playlistArr.push(item.data());
               });
-            });
-          await setDocumentState(playlistArr);
+              await setDocumentState(playlistArr);
+            }
+          );
         })
         .catch(err => {
           console.log(err);


### PR DESCRIPTION
User can search for a song in the tuneroom, and add that song. Song will populate the firestore, then get rendered via context throughout the app in realtime. Context is now listening to a QuerySnapshot and modifying the tracks array based on the changes. 

Also modified the firestore to add a 'votes' key into the initial song creation to address NaN bug for voting for a newly created song.