### PR TITLE
Create workflow context

### DIFF
--- a/client/src/api/firebase/firebaseApi.js
+++ b/client/src/api/firebase/firebaseApi.js
@@ -36,6 +36,7 @@ function getPlaylistFromDb(next) {
 }
 
 function addTrackToDb(track, accessCodeId) {
+  console.log('accessCodeId: ', accessCodeId);
   const playlistRef = db.doc(`playlists/${accessCodeId}`);
   playlistRef
     .collection('tracks')

--- a/client/src/api/spotify/spotifyApi.js
+++ b/client/src/api/spotify/spotifyApi.js
@@ -11,6 +11,8 @@ function createSpotifyPlaylist(
   userId,
   playlistName,
   setMyAccessCode,
+  setDocumentPlaylistId,
+  setDocumentOwnerId,
   navigate
 ) {
   const accessCodeId = Math.random()
@@ -36,8 +38,10 @@ function createSpotifyPlaylist(
         playlistName,
         uri
       );
+      await setDocumentPlaylistId({ data: playlistId });
+      await setDocumentOwnerId({ data: ownerId });
     })
-    .then(navigate(`/tuneroom/${accessCodeId}`))
+    .then(navigate(`/add/${accessCodeId}`))
     .catch(error => {
       return error;
     });
@@ -53,7 +57,11 @@ function searchTracks(query, setTrackResults) {
     });
 }
 
-function addTrack(ownerId, playlistId, track) {
+function addTrack(ownerId, playlistId, accessCodeId, track) {
+  console.log('track: ', track);
+  console.log('ownerId: ', ownerId);
+  console.log('accessCodeID: ', accessCodeId);
+  console.log('track: ', track);
   db.doc(`users/${ownerId}`)
     .get()
     .then(doc => {
@@ -73,7 +81,7 @@ function addTrack(ownerId, playlistId, track) {
           .then(response => {
             if (response.status === 201) {
               const accessCode = localStorage.getItem('accessCode');
-              addTrackToDb(track, accessCode);
+              addTrackToDb(track, accessCodeId);
             }
           })
           .catch(error => error);

--- a/client/src/api/spotify/spotifyApi.js
+++ b/client/src/api/spotify/spotifyApi.js
@@ -13,6 +13,8 @@ function createSpotifyPlaylist(
   setMyAccessCode,
   setDocumentPlaylistId,
   setDocumentOwnerId,
+  setDocumentPlaylistName,
+  setDocumentUri,
   navigate
 ) {
   const accessCodeId = Math.random()
@@ -38,8 +40,11 @@ function createSpotifyPlaylist(
         playlistName,
         uri
       );
+      // after playlist creation, we need to set this in context to pass throughout the app
       await setDocumentPlaylistId({ data: playlistId });
       await setDocumentOwnerId({ data: ownerId });
+      await setDocumentPlaylistName({ data: playlistName });
+      await setDocumentUri({ uri });
     })
     .then(navigate(`/add/${accessCodeId}`))
     .catch(error => {

--- a/client/src/api/spotify/spotifyApi.js
+++ b/client/src/api/spotify/spotifyApi.js
@@ -63,10 +63,6 @@ function searchTracks(query, setTrackResults) {
 }
 
 function addTrack(ownerId, playlistId, accessCodeId, track) {
-  console.log('track: ', track);
-  console.log('ownerId: ', ownerId);
-  console.log('accessCodeID: ', accessCodeId);
-  console.log('track: ', track);
   db.doc(`users/${ownerId}`)
     .get()
     .then(doc => {
@@ -85,7 +81,6 @@ function addTrack(ownerId, playlistId, accessCodeId, track) {
           )
           .then(response => {
             if (response.status === 201) {
-              const accessCode = localStorage.getItem('accessCode');
               addTrackToDb(track, accessCodeId);
             }
           })

--- a/client/src/components/addsong.js
+++ b/client/src/components/addsong.js
@@ -122,16 +122,27 @@ const AddSong = props => {
   }, [documentOwnerId, user]);
 
   const search = e => {
+    console.log(documentOwnerId.data);
+    console.log(documentPlaylistId.data);
+    // console.log(result);
     setStateQuery({ query: e.target.value });
   };
 
   const handleAddTrack = async result => {
-    // console.log(localStorage.getItem('accessCode'));
-    let addSongAccessCode = localStorage.getItem('accessCode');
-    // addStartingTrack(result, setMyAccessCode, setDocumentUri, navigate);
-    await setMyAccessCode(addSongAccessCode);
-    addTrack(documentOwnerId.data, documentPlaylistId.data, result);
-    setTrackResults({ data: '' });
+    console.log('result: ', result);
+    console.log('this: ', documentPlaylistId.data);
+    // need to pass this all the way to addTrackDb method in firebaseApi
+    let accessCodeId = window.location.pathname.split('/').pop();
+    await addTrack(
+      documentOwnerId.data,
+      documentPlaylistId.data,
+      accessCodeId,
+      result
+    );
+    // await setTrackResults({ data: '' });
+    if (!window.location.pathname.includes('tuneroom')) {
+      await navigate(`/tuneroom/${accessCodeId}`);
+    }
   };
 
   const handleKeyPress = e => {

--- a/client/src/components/addsong.js
+++ b/client/src/components/addsong.js
@@ -122,15 +122,10 @@ const AddSong = props => {
   }, [documentOwnerId, user]);
 
   const search = e => {
-    console.log(documentOwnerId.data);
-    console.log(documentPlaylistId.data);
-    // console.log(result);
     setStateQuery({ query: e.target.value });
   };
 
   const handleAddTrack = async result => {
-    console.log('result: ', result);
-    console.log('this: ', documentPlaylistId.data);
     // need to pass this all the way to addTrackDb method in firebaseApi
     let accessCodeId = window.location.pathname.split('/').pop();
     await addTrack(
@@ -139,7 +134,6 @@ const AddSong = props => {
       accessCodeId,
       result
     );
-    // await setTrackResults({ data: '' });
     if (!window.location.pathname.includes('tuneroom')) {
       await navigate(`/tuneroom/${accessCodeId}`);
     }

--- a/client/src/components/create.js
+++ b/client/src/components/create.js
@@ -73,7 +73,12 @@ const Create = () => {
     playlistName: '',
   });
 
-  const { myAccessCode, setMyAccessCode } = useContext(SpotifyContext);
+  const {
+    myAccessCode,
+    setMyAccessCode,
+    setDocumentPlaylistId,
+    setDocumentOwnerId,
+  } = useContext(SpotifyContext);
 
   useEffect(() => {
     localStorage.setItem('isLoading', false);
@@ -92,6 +97,8 @@ const Create = () => {
         user.uid,
         playlist.playlistName,
         setMyAccessCode,
+        setDocumentPlaylistId,
+        setDocumentOwnerId,
         navigate
       );
     }
@@ -116,6 +123,8 @@ const Create = () => {
             user.uid,
             playlist.playlistName,
             setMyAccessCode,
+            setDocumentPlaylistId,
+            setDocumentOwnerId,
             navigate
           )
         }

--- a/client/src/components/create.js
+++ b/client/src/components/create.js
@@ -78,6 +78,8 @@ const Create = () => {
     setMyAccessCode,
     setDocumentPlaylistId,
     setDocumentOwnerId,
+    setDocumentPlaylistName,
+    setDocumentUri,
   } = useContext(SpotifyContext);
 
   useEffect(() => {
@@ -99,6 +101,8 @@ const Create = () => {
         setMyAccessCode,
         setDocumentPlaylistId,
         setDocumentOwnerId,
+        setDocumentPlaylistName,
+        setDocumentUri,
         navigate
       );
     }
@@ -125,6 +129,8 @@ const Create = () => {
             setMyAccessCode,
             setDocumentPlaylistId,
             setDocumentOwnerId,
+            setDocumentPlaylistName,
+            setDocumentUri,
             navigate
           )
         }

--- a/client/src/components/join.js
+++ b/client/src/components/join.js
@@ -99,9 +99,11 @@ const Join = () => {
           }
         });
         if (isMatch) {
+          console.log(documentUri);
           setFlashMessage(false);
-          await setDocumentUri(documentUri);
+          await setDocumentUri({ data: documentUri });
           await setMyAccessCode(searchQuery.code);
+
           await localStorage.setItem('accessCode', searchQuery.code);
           await navigate(`/tuneroom/${searchQuery.code}`);
         } else {

--- a/client/src/components/tuneroom.js
+++ b/client/src/components/tuneroom.js
@@ -11,6 +11,7 @@ import { vote } from '../api/firebase/firebaseApi';
 import { theme, mixins } from '../styles';
 
 import AddSong from './addsong';
+import { navigate } from '@reach/router/lib/history';
 
 const { fonts, fontSizes, colors } = theme;
 
@@ -146,6 +147,7 @@ function TuneRoom() {
 
   return (
     <TuneRoomContainer>
+      <Link to="/join">Join Different Tuneroom</Link>
       <PlaylistName>{documentPlaylistName.data}</PlaylistName>
       <PlayerContainer>
         <SpotifyPlayer

--- a/client/src/context/spotifyContext.js
+++ b/client/src/context/spotifyContext.js
@@ -28,7 +28,6 @@ export const SpotifyProvider = ({ children }) => {
     } else {
       setMyAccessCode(window.location.pathname.split('/').pop());
     }
-    let urlCode = window.location.pathname.split('/').pop();
     async function fetchData() {
       const playlistRef = db.doc(`playlists/${myAccessCode}`);
       playlistRef

--- a/client/src/context/spotifyContext.js
+++ b/client/src/context/spotifyContext.js
@@ -23,7 +23,12 @@ export const SpotifyProvider = ({ children }) => {
   });
   useEffect(() => {
     // this localStorage call allows tunes to persist through tuneroom refresh
-    setMyAccessCode(localStorage.getItem('accessCode'));
+    if (window.location.pathname == '/') {
+      setMyAccessCode('default');
+    } else {
+      setMyAccessCode(window.location.pathname.split('/').pop());
+    }
+    let urlCode = window.location.pathname.split('/').pop();
     async function fetchData() {
       const playlistRef = db.doc(`playlists/${myAccessCode}`);
       playlistRef
@@ -35,7 +40,6 @@ export const SpotifyProvider = ({ children }) => {
           await setDocumentOwnerId({ data: doc.data().ownerId });
           await setDocumentPlaylistId({ data: doc.data().playlistId });
           await setDocumentUri({ uri: doc.data().uri });
-          console.log(documentUri);
           await setDocumentPlaylistName({ data: doc.data().playlistName });
           await playlistRef.collection('tracks').onSnapshot(
             {

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -21,7 +21,7 @@ const ReactRouter = () => {
           <Home path="/" />
           <Create path="/create" />
           <Join path="/join" />
-          <AddSong path="/add/:accessCode" />
+          <AddSong path="/add/:code" />
           {/* <TuneRoom path="/tuneroom" /> */}
           <TuneRoom path="/tuneroom/:code" />
         </Router>

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -21,7 +21,7 @@ const ReactRouter = () => {
           <Home path="/" />
           <Create path="/create" />
           <Join path="/join" />
-          <AddSong path="/add" />
+          <AddSong path="/add/:accessCode" />
           {/* <TuneRoom path="/tuneroom" /> */}
           <TuneRoom path="/tuneroom/:code" />
         </Router>


### PR DESCRIPTION
On playlist creation, the various playlist properties are set on creation, and then context sets them based on localStorage to persist through page refresh.

There is still a bug. When on a playlist, and user clicks 'back' then rejoins a room, the playlist does not autoplay. Interestingly, when you manually add the /join parameter to the url string, then navigate to a room, it DOES autoplay...something to do with browser history maybe?